### PR TITLE
Fix addstr() _curses.error on Ubuntu

### DIFF
--- a/snake/graphics.py
+++ b/snake/graphics.py
@@ -12,10 +12,15 @@ def drawTile(x, y, tile='', color=None):
 
     x = x * 2 + stage.padding[3] * 2 + stage.width / 2
     y += stage.padding[0] + stage.height / 2
-
-    screen.addstr(y, x, tile, color)
+    try:
+        screen.addstr(y, x, tile, color)
+    except curses.error:
+        pass
     if (len(tile) < 2):
-        screen.addstr(y, x + 1, tile, color)
+        try:
+            screen.addstr(y, x + 1, tile, color)
+        except curses.error:
+            pass
 
 
 def drawGameOver():


### PR DESCRIPTION
Fixes the following game-breaking error on Ubuntu (python  2.7.6):
```
File "snake/graphics.py", line 16, in drawTile
screen.addstr(y, x, tile, color)
_curses.error: addstr() returned ERR
```
See this thread for more information: http://ubuntuforums.org/showthread.php?t=457689&p=3208206#post3208206
Cheers